### PR TITLE
meson: add install script

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,5 +3,7 @@ project(
     version: '1.0'
 )
 
+meson.add_install_script('meson/post_install.py', join_paths(get_option('prefix'), get_option('datadir')))
+
 subdir('bin')
 subdir('data')

--- a/meson/post_install.py
+++ b/meson/post_install.py
@@ -2,9 +2,8 @@
 
 import os
 import subprocess
-
-schemadir = os.path.join(os.environ['MESON_INSTALL_PREFIX'], 'share', 'glib-2.0', 'schemas')
+import sys
 
 if not os.environ.get('DESTDIR'):
-	print('Compiling gsettings schemas...')
-	subprocess.call(['glib-compile-schemas', schemadir])
+    print('Compiling gsettings schemas...')
+    subprocess.call(['glib-compile-schemas', os.path.join(sys.argv[1], 'glib-2.0', 'schemas')], shell=False)


### PR DESCRIPTION
##### Motivation

It appears that the install script was never included though `meson/post_install.py` existed.
This fixes #8 because the gsettings were never being compiled.